### PR TITLE
Display menu lists in mobile screen

### DIFF
--- a/frontend/src/app/header/header.component.css
+++ b/frontend/src/app/header/header.component.css
@@ -1,21 +1,21 @@
-    @import url('../../styles.css');
-    .nav-item {
-        padding: 2px;
-        text-align: center;
-    }
+@import url('../../styles.css');
+.nav-item {
+    padding: 2px;
+    text-align: center;
+}
 
-    .navbar-brand-logo {
-        height: 61px;
-    }
+.navbar-brand-logo {
+    height: 61px;
+}
 
+.slash {
+    display: none;
+}
+
+@media screen and (min-width:768px) {
     .slash {
-        display: none;
+        display: block;
+        padding: .5rem;
+        color: var(--dark);
     }
-
-    @media screen and (min-width:768px) {
-        .slash {
-            display: block;
-            padding: .5rem;
-            color: var(--dark);
-        }
-    }
+}

--- a/frontend/src/app/header/header.component.css
+++ b/frontend/src/app/header/header.component.css
@@ -1,14 +1,21 @@
-@import url('../../styles.css');
-.nav-item {
-    padding: 2px;
-    margin-left: 7px;
-}
+    @import url('../../styles.css');
+    .nav-item {
+        padding: 2px;
+        text-align: center;
+    }
 
-.navbar-brand-logo {
-    height: 61px;
-}
+    .navbar-brand-logo {
+        height: 61px;
+    }
 
-.slash {
-    padding: .5rem;
-    color: var(--dark);
-}
+    .slash {
+        display: none;
+    }
+
+    @media screen and (min-width:768px) {
+        .slash {
+            display: block;
+            padding: .5rem;
+            color: var(--dark);
+        }
+    }

--- a/frontend/src/app/header/header.component.html
+++ b/frontend/src/app/header/header.component.html
@@ -8,7 +8,7 @@
                 </button>
             </div>
             <div class="collapse navbar-collapse" id="navbarCollapse">
-                <ul class="navbar-nav mr-auto d-flex col-sm-12 justify-content-between">
+                <ul class="navbar-nav mr-auto d-flex col-sm-12 justify-content-between align-items-center">
                     <li class="nav-item">
                         <a class="nav-link" routerLink="/complete">Complete Calculation</a>
                     </li>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,13 +1,21 @@
 <!doctype html>
 <html lang="en">
+
 <head>
-  <meta charset="utf-8">
-  <title>Frontend</title>
-  <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+    <meta charset="utf-8">
+    <title>Frontend</title>
+    <base href="/">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
+
 <body>
-  <app-root></app-root>
+    <app-root></app-root>
+    <!-- Optional JavaScript -->
+    <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 </body>
+
 </html>


### PR DESCRIPTION
### 変更内容
モバイルで閲覧時にハンバーガメニューが展開されるようにしました。

イメージ画像
＜PC＞
<img width="995" alt="スクリーンショット 2020-02-23 16 19 23" src="https://user-images.githubusercontent.com/44167315/75105620-f114bb80-5658-11ea-8e85-7f6afe5d53cf.png">

＜タブレット＞
<img width="759" alt="スクリーンショット 2020-02-23 16 19 30" src="https://user-images.githubusercontent.com/44167315/75105623-f2de7f00-5658-11ea-8d5f-34ef2e764a7b.png">

＜モバイル＞
<img width="485" alt="スクリーンショット 2020-02-23 16 25 08" src="https://user-images.githubusercontent.com/44167315/75105634-16a1c500-5659-11ea-9301-f302480270be.png">
